### PR TITLE
remove new label in tickets button

### DIFF
--- a/rubycon.it/_includes/hero.html
+++ b/rubycon.it/_includes/hero.html
@@ -14,7 +14,6 @@
                 <div class="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-4">
                     <a href="{{ site.event.tickets_url }}" class="relative inline-block bg-white text-red-950 px-8 py-3 rounded-md font-bold text-lg hover:bg-gray-100 transition duration-300 text-center">
                         Tickets for sale
-                        <span class="absolute -top-2 -right-2 bg-yellow-400 text-gray-900 text-xs font-bold px-2 py-1 rounded-full">new</span>
                     </a>
                     <a href="#about" class="border-2 border-white text-white px-8 py-3 rounded-md font-bold text-lg hover:bg-white hover:text-red-950 transition duration-300 text-center" aria-label="Learn more about Rubycon Italy">learn more</a>
                 </div>


### PR DESCRIPTION
Removing the `new` label from the button since tickets have been available for a while

<img width="598" height="359" alt="image" src="https://github.com/user-attachments/assets/0c18fa17-0cdb-4277-9218-8f3a8358c817" />
