### PR TITLE
Test: Use underscore for integer in schedule time

### DIFF
--- a/rubycon.it/_includes/dsl/content.rb
+++ b/rubycon.it/_includes/dsl/content.rb
@@ -59,7 +59,7 @@ Rubycon::Agenda.schedule(Date.new(2026, 5, 8)) do
 
   # Keep the conversation going, or refill
   # the batteries in the hotel, whatever you prefer.
-  pause at: "18:00",
+  pause at: 18_00,
         desc: "Drinks or Shower or Nap",
         tags: %w[optional]
 


### PR DESCRIPTION
As requested, testing the use of underscore notation for a time integer in a Ruby file. \n\n**Warning:** I was unable to test the Jekyll build locally due to a Ruby environment permission issue, so this change might break the site build. Please review the CI checks carefully.